### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : salsa20
+      VLNV : secworks:crypto:salsa20
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: salsa20
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : salsa20
+      VLNV : secworks:crypto:salsa20
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: salsa20
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(FP_CORE_UTIL) 20
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]
+set ::env(CLOCK_PERIOD) "36.73"

--- a/salsa20.core
+++ b/salsa20.core
@@ -1,0 +1,30 @@
+CAPI=2:
+
+name : secworks:crypto:salsa20
+
+filesets:
+  rtl:
+    files:
+      - src/rtl/salsa20_qr.v
+      - src/rtl/salsa20_core.v
+      - src/rtl/salsa20.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets: [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: salsa20
+
+  sky130:
+    default_tool : openlane
+    filesets: [rtl, sky130]
+    toplevel : salsa20


### PR DESCRIPTION
This adds a core description file for the salsa20 core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register salsa20 as a library in the workspace
fusesoc library add salsa20 /path/to/salsa20
 #...if repo is available locally or...
fusesoc library add salsa20 https://github.com/secworks/salsa20
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint secworks:crypto:salsa20
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 secworks:crypto:salsa20
 #List all targets
fusesoc core show secworks:crypto:salsa20